### PR TITLE
GA add campaign business unit custom dimension

### DIFF
--- a/common/app/views/fragments/analytics/google.scala.html
+++ b/common/app/views/fragments/analytics/google.scala.html
@@ -72,6 +72,7 @@
         ga('@{trackerName}.set', 'dimension15', identityId);
         ga('@{trackerName}.set', 'dimension16', isLoggedIn);
         ga('@{trackerName}.set', 'dimension21', getQueryParam('INTCMP')); @* internal campaign code *@
+        ga('@{trackerName}.set', 'dimension22', getQueryParam('CMP_BUNIT')); @* campaign business unit*@
     }
 
     @defining(GoogleAnalyticsAccount.editorialTracker.trackerName) { trackerName =>


### PR DESCRIPTION
## What does this change?

Adds another custom dimension to Google Analytics
## What is the value of this and can you measure success?

It helps business unit report more easily on their marketing campaigns by allowing them to filter by business unit
## Does this affect other platforms - Amp, Apps, etc?

Not directly. But other platforms should follow suit.

<!--
Run the AMP test suite with `make validate-amp`

You should also validate a specific page that your change affects by adding the amp query string along with the development hash: http://localhost:3000/sport/2016/aug/25/katie-ledecky-first-pitch-washington-nationals-bryce-harper?amp=1#development=1

The AMP validation results will appear in your console.
-->
## Screenshots

N/A
## Request for comment

@cb372 @dominickendrick @emma-p

<!--
*Does this PR meet the [contributing guidelines](https://github.com/guardian/frontend/blob/issue_pr_templates/.github/CONTRIBUTING.md#submission)?*
-->
